### PR TITLE
CI: verify Windows /utf-8 fix simulates CP936 end-to-end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,72 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
-      - name: Verify /utf-8 is set for MSVC
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Verify /utf-8 is set for MSVC in windows/CMakeLists.txt
         shell: bash
         run: |
           grep -q '/utf-8' windows/CMakeLists.txt \
             || { echo "::error::windows/CMakeLists.txt is missing /utf-8 — see chinese-pc-compat.md"; exit 1; }
-      - run: cd example && flutter build windows
+
+      - name: Verify ci/cp936_repro.cpp covers every non-ASCII char in windows/
+        shell: bash
+        run: python ci/check_unicode_inventory.py
+
+      - name: Verify ci/cp936_repro.cpp has no UTF-8 BOM
+        shell: bash
+        run: |
+          bom=$(head -c 3 ci/cp936_repro.cpp | od -An -tx1 | tr -d ' \n')
+          if [ "$bom" = "efbbbf" ]; then
+            echo "::error::ci/cp936_repro.cpp must not have a BOM (MSVC would auto-detect UTF-8 and bypass /source-charset:.936)"
+            exit 1
+          fi
+          echo "OK: no BOM"
+
+      - name: CP936 simulation without /utf-8 must fail with C4819/C2220
+        shell: cmd
+        run: |
+          cl /c /WX /source-charset:.936 /execution-charset:.936 /nologo ci\cp936_repro.cpp > cl.log 2>&1
+          set CL_EXIT=%errorlevel%
+          type cl.log
+          if %CL_EXIT% equ 0 (
+            echo ::error::Expected C4819/C2220 but compile succeeded — CP936 simulation is not triggering the bug
+            exit /b 1
+          )
+          findstr /c:"C4819" cl.log >nul
+          if errorlevel 1 (
+            echo ::error::cl.exe failed but did not emit C4819 — test is not reproducing the real bug
+            exit /b 1
+          )
+          findstr /c:"C2220" cl.log >nul
+          if errorlevel 1 (
+            echo ::error::cl.exe failed but did not emit C2220 — /WX promotion is not working as expected
+            exit /b 1
+          )
+          echo OK: CP936 simulation reproduced C4819/C2220 as expected
+          exit /b 0
+
+      - name: CP936 simulation with /utf-8 must succeed (proves the fix)
+        shell: cmd
+        run: cl /c /WX /source-charset:.936 /execution-charset:.936 /utf-8 /nologo ci\cp936_repro.cpp
+
+      - name: Build the example (generates the plugin vcxproj)
+        run: cd example && flutter build windows
+
+      - name: Verify /utf-8 is threaded into the generated plugin vcxproj
+        shell: bash
+        run: |
+          vcxproj=$(find example/build/windows -name 'camera_desktop_plugin.vcxproj' | head -n1)
+          if [ -z "$vcxproj" ]; then
+            echo "::error::camera_desktop_plugin.vcxproj not found under example/build/windows"
+            find example/build/windows -name '*.vcxproj' || true
+            exit 1
+          fi
+          echo "Inspecting: $vcxproj"
+          if ! grep -q '/utf-8' "$vcxproj"; then
+            echo "::error::/utf-8 missing from $vcxproj — CMake did not thread the flag through"
+            echo "--- vcxproj contents ---"
+            cat "$vcxproj"
+            exit 1
+          fi
+          echo "OK: /utf-8 present in $vcxproj"

--- a/ci/check_unicode_inventory.py
+++ b/ci/check_unicode_inventory.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Assert that every non-ASCII character appearing in windows/*.cpp|*.h also
+appears in ci/cp936_repro.cpp.
+
+Purpose: the CP936 simulation step in CI compiles cp936_repro.cpp to prove that
+/utf-8 resolves C4819 for the exact character set we use. If a new file adds a
+new Unicode character (e.g. a µ in a comment) without updating the synthetic
+repro, CI would silently keep passing while real Simplified-Chinese Windows
+hosts would start failing again.
+
+Run from the repo root. Exits non-zero with a clear message if drift is found.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+
+def non_ascii_chars(path: pathlib.Path) -> set[str]:
+    return {c for c in path.read_text(encoding="utf-8") if ord(c) > 0x7F}
+
+
+def main() -> int:
+    windows_sources = sorted(
+        list(pathlib.Path("windows").glob("*.cpp"))
+        + list(pathlib.Path("windows").glob("*.h"))
+    )
+    if not windows_sources:
+        print("::error::No windows/*.cpp|*.h files found — run from repo root.")
+        return 1
+
+    real: set[str] = set()
+    per_file: dict[str, set[str]] = {}
+    for f in windows_sources:
+        chars = non_ascii_chars(f)
+        if chars:
+            per_file[str(f)] = chars
+        real |= chars
+
+    synthetic_path = pathlib.Path("ci/cp936_repro.cpp")
+    if not synthetic_path.exists():
+        print(f"::error::{synthetic_path} missing.")
+        return 1
+
+    synthetic = non_ascii_chars(synthetic_path)
+
+    missing = real - synthetic
+    if missing:
+        print("::error::ci/cp936_repro.cpp is missing characters used in windows/ sources.")
+        print("Missing:")
+        for c in sorted(missing):
+            sources = [f for f, cs in per_file.items() if c in cs]
+            print(f"  U+{ord(c):04X}  {c!r}  (in: {', '.join(sources)})")
+        print()
+        print("Fix: add these characters to ci/cp936_repro.cpp so the CP936 CI")
+        print("simulation stays representative of the real sources.")
+        return 1
+
+    print(f"OK: all {len(real)} non-ASCII chars in windows/ are covered by {synthetic_path}.")
+    for c in sorted(real):
+        print(f"  U+{ord(c):04X}  {c}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/cp936_repro.cpp
+++ b/ci/cp936_repro.cpp
@@ -1,0 +1,25 @@
+// Synthetic CP936-reproduction file for CI.
+//
+// This file deliberately contains every non-ASCII character that appears in
+// windows/*.cpp and windows/*.h, so that compiling it with
+//   cl /c /WX /source-charset:.936 /execution-charset:.936
+// reproduces the exact C4819 / C2220 failure that users see on Simplified
+// Chinese Windows hosts (where GetACP() == 936 / GBK).
+//
+// DO NOT add a BOM to this file. With a BOM, MSVC auto-detects UTF-8 and
+// ignores /source-charset:.936, which would defeat the test.
+//
+// If you add a new non-ASCII character anywhere under windows/, the CI step
+// `ci/check_unicode_inventory.py` will fail until you add that character
+// here. Keep the inventory below in sync.
+//
+// Covered characters (also listed explicitly so a byte-level grep for the
+// UTF-8 sequences finds them here):
+//   U+2026 HORIZONTAL ELLIPSIS          …
+//   U+2192 RIGHTWARDS ARROW             →
+//   U+2194 LEFT RIGHT ARROW             ↔
+//   U+2264 LESS-THAN OR EQUAL TO        ≤
+//   U+2500 BOX DRAWINGS LIGHT HORIZONTAL ─
+//
+// No code needed — /c (compile only) is sufficient to trigger C4819 on the
+// comment bytes above.


### PR DESCRIPTION
Adds a four-part CI verification for the fix that closed #2:

1. Grep guard: `windows/CMakeLists.txt` must contain `/utf-8`.
2. Inventory check: every non-ASCII char in `windows/*.cpp|*.h` must also appear in `ci/cp936_repro.cpp`.
3. MSVC CP936 simulation:
   - without `/utf-8` must fail with C4819/C2220 (proves bug mechanism)
   - with `/utf-8` must succeed (proves fix resolves it)
4. Post-build vcxproj inspection: after `flutter build windows`, the generated `camera_desktop_plugin.vcxproj` must contain `/utf-8` (proves CMake actually threads the flag through to MSBuild).

DO NOT MERGE until all new checks are green. Branch will be squashed and fast-forwarded into main once validated.